### PR TITLE
Add price_formatted and list_price_formatted fields

### DIFF
--- a/Controller/Product/Index.php
+++ b/Controller/Product/Index.php
@@ -32,21 +32,32 @@ class Index extends AbstractAction
     protected $imageHandler;
 
     /**
-     * Popup controller constructor.
+     * @var \Clerk\Clerk\Helper\Product
+     */
+    protected $productHelper;
+
+    /**
+     * Product Index constructor.
      *
      * @param Context $context
      * @param ScopeConfigInterface $scopeConfig
+     * @param CollectionFactory $productCollectionFactory
+     * @param \Clerk\Clerk\Helper\Product $productHelper
+     * @param Image $imageHandler
+     * @param LoggerInterface $logger
      */
     public function __construct(
         Context $context,
         ScopeConfigInterface $scopeConfig,
         CollectionFactory $productCollectionFactory,
+        \Clerk\Clerk\Helper\Product $productHelper,
         Image $imageHandler,
         LoggerInterface $logger
     )
     {
         $this->collectionFactory = $productCollectionFactory;
         $this->imageHandler = $imageHandler;
+        $this->productHelper = $productHelper;
         $this->addFieldHandlers();
 
         parent::__construct($context, $scopeConfig, $logger);
@@ -67,6 +78,13 @@ class Index extends AbstractAction
             }
         });
 
+        //Add price_formatted fieldhandler
+        $this->addFieldHandler('price_formatted', function($item) {
+            $priceHandler = $this->fieldHandlers['price'];
+            $price = $priceHandler($item);
+            return $this->productHelper->formatCurrency($price);
+        });
+
         //Add list_price fieldhandler
         $this->addFieldHandler('list_price', function($item) {
             try {
@@ -81,6 +99,13 @@ class Index extends AbstractAction
             } catch(\Exception $e) {
                 return 0;
             }
+        });
+
+        //Add list_price_formatted fieldhandler
+        $this->addFieldHandler('list_price_formatted', function($item) {
+            $priceHandler = $this->fieldHandlers['list_price'];
+            $price = $priceHandler($item);
+            return $this->productHelper->formatCurrency($price);
         });
 
 
@@ -132,6 +157,8 @@ class Index extends AbstractAction
             'description',
             'price',
             'list_price',
+            'price_formatted',
+            'list_price_formatted',
             'image',
             'url',
             'categories',

--- a/Helper/Product.php
+++ b/Helper/Product.php
@@ -24,10 +24,12 @@ class Product
      */
     public function __construct(
         \Magento\CatalogInventory\Helper\Stock $stockHelper,
-        \Magento\CatalogInventory\Model\StockRegistryStorage $stockRegistryStorage
+        \Magento\CatalogInventory\Model\StockRegistryStorage $stockRegistryStorage,
+        \Magento\Framework\Pricing\Helper\Data $pricingHelper
     ) {
         $this->stockHelper = $stockHelper;
         $this->stockRegistryStorage = $stockRegistryStorage;
+        $this->pricingHelper = $pricingHelper;
     }
 
     /**
@@ -48,5 +50,16 @@ class Product
         $this->stockHelper->assignStatusToProduct($product);
 
         return $product->isSalable();
+    }
+
+    /**
+     * Format the given value as currency
+     *
+     * @param float $value
+     * @return mixed
+     */
+    public function formatCurrency($value)
+    {
+        return $this->pricingHelper->currency($value, true, false);
     }
 }

--- a/Model/Indexer/Product/Action/Rows.php
+++ b/Model/Indexer/Product/Action/Rows.php
@@ -177,12 +177,17 @@ class Rows
 
         $imageUrl = $this->imageHandler->handle($product);
 
+        $price = $product->getFinalPrice();
+        $listPrice = $product->getPrice();
+
         $productItem = [
             'id' => $product->getId(),
             'name' => $product->getName(),
             'description' => $product->getDescription(),
-            'price' => $product->getFinalPrice(),
-            'list_price' => $product->getPrice(),
+            'price' => $price,
+            'price_formatted' => $this->helper->formatCurrency($price),
+            'list_price' => $listPrice,
+            'list_price_formatted' => $this->helper->formatCurrency($listPrice),
             'image' => $imageUrl,
             'url' => $product->getUrlModel()->getUrl($product),
             'categories' => $product->getCategoryIds(),


### PR DESCRIPTION
Clerk module has built-in "price" and "list_price" fields to sync. They both are float.
When it comes to display these prices to user, for the moment it's possible to use Clerk's formatting methods (see https://docs.clerk.io/docs/template-language), there are two functions: "money" and "money_eu". E.g.:
{{money price 2 "," "."}}
{{money list_price 2 "," "."}}

This way the information how to format a currency is doubled: Magento itself has currency format for prices, now Clerk should know how to format prices. I think the better approach is to have a "single source of truth": so, Magento formats prices and sends it to Clerk, Clerk should not keep any logic how to format data, Clerk should display it as it is.
